### PR TITLE
retrieves connection string from config for commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "version": "5.0.3",
     "require": {
         "php": "^8.1",
-        "illuminate/session": "^10.0",
+        "illuminate/session": "^10.0|^11.0",
         "mongodb/laravel-mongodb": "^4.0"
     },
     "license": "MIT",

--- a/src/Console/Commands/MongodbSessionDropIndex.php
+++ b/src/Console/Commands/MongodbSessionDropIndex.php
@@ -33,9 +33,10 @@ class MongodbSessionDropIndex extends Command
      */
     public function handle()
     {
+        $connection = config('session.connection');
         $collection = config('session.table');
 
-        DB::connection('mongodb')->getMongoDB()->command([
+        DB::connection($connection)->getMongoDB()->command([
             'dropIndexes' => $collection,
             'index' => $this->argument('index'),
         ], [

--- a/src/Console/Commands/MongodbSessionIndex.php
+++ b/src/Console/Commands/MongodbSessionIndex.php
@@ -33,9 +33,10 @@ class MongodbSessionIndex extends Command
      */
     public function handle()
     {
+        $connection = config('session.connection');
         $collection = config('session.table');
 
-        DB::connection('mongodb')->getMongoDB()->command([
+        DB::connection($connection)->getMongoDB()->command([
             'createIndexes' => $collection,
             'indexes' => [
                 [


### PR DESCRIPTION
This PR retrieves a connection string retrieved from config rather than a hard coded  'mongodb' in the command classes that add & drop session index to use - otherwise if session.connection in config is not 'mongodb' the commnds will attempt to use a different connection string than SessionServiceProvider